### PR TITLE
Add json route for todos by ID, and better docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ ruby '2.5.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
 
-# Uncomment this line and comment the next one to switch to MySQL (run `bundle install` afterwards)
-#gem 'mysql2'
+gem 'mysql2', '~> 0.5'
 gem 'pg'
 
 # Use Puma as the app server
@@ -18,7 +17,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
-gem 'mysql2', '~> 0.5'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
@@ -39,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'listen', '>= 3.0.5', '< 3.2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -48,7 +47,6 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ and then again:
 
 to do a normal deploy.
 
+## Seed data, manual trigger with one push:
+
+Alternatively, you may do a normal `cf push`, and then run the following (admittedly unwieldy) command:
+
+`cf ssh scf-rails-example -c  "export PATH=/home/vcap/deps/0/bin:/usr/local/bin:/usr/bin:/bin && export BUNDLE_PATH=/home/vcap/deps/0/vendor_bundle/ruby/2.5.0 && export BUNDLE_GEMFILE=/home/vcap/app/Gemfile && cd app && bundle exec rake db:seed"`
+
+This triggers the seed task while the app is already running, without needing to restage/restart.
 
 ## Useful links
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,0 +1,14 @@
+class TodosController < ApplicationController
+  def json_response(object, status = :ok)
+    render json: object, status: status
+  end
+
+  def index
+    @todos = Todo.all
+    json_response(@todos)
+  end
+
+  def show
+    json_response(Todo.find(params[:id]))
+  end
+end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,2 +1,3 @@
 class Todo < ApplicationRecord
+  validates_presence_of :text 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'home#index'
+  resources  :todos
 end

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,9 @@
 ---
 applications:
 - name: scf-rails-example
-  random-route: true
   memory: 256M
   instances: 1
   path: .
   command: bundle exec rake db:migrate && bundle exec rails s -p $PORT
   services:
-    - scf-rails-example-db
+  - scf-rails-example-db


### PR DESCRIPTION
- Add instructions to trigger the seed task without having to repush
  or restage the app
- Remove cruft from Gemfile
- Add todos controller and routes. An individual todo item can now be
  accessed via `$DOMAIN/todos/:id`
- Remove `random-route: true` from manifest. This can be specified on
  the command-line when pushing, but *can't* be toggled off with a flag
  to `cf push`. Turning this off by default makes QA pipeline
  integration easier